### PR TITLE
Fix PATH setting so it plays nice with multi buildpacks

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,20 +1,19 @@
 #!/usr/bin/env bash
 
+BUILD_DIR=$1
+CACHE_DIR=${2:-}
+ENV_DIR=${3:-}
+BP_DIR=$(cd "$(dirname "${0:-}")"; cd ..; pwd)
+
 echo "-----> Installing Sentry-CLI"
 # Install Sentry CLI
-mkdir -p $1/vendor/bin
-curl --silent -L -o $1/vendor/bin/sentry-cli https://downloads.sentry-cdn.com/sentry-cli/1.47.1/sentry-cli-Linux-x86_64
-chmod a+x $1/vendor/bin/sentry-cli
+mkdir -p "$BUILD_DIR/vendor/bin"
+curl --silent -L -o "$BUILD_DIR/vendor/bin/sentry-cli" https://downloads.sentry-cdn.com/sentry-cli/1.47.1/sentry-cli-Linux-x86_64
+chmod a+x "$BUILD_DIR/vendor/bin/sentry-cli"
 
 # Setting environment variables in .profile.d script (sourced at dyno startup)
 echo "-----> Setting Environment Variables"
-mkdir -p "$1"/.profile.d
-cat <<EOF >"$1"/.profile.d/sentry-cli.sh
-PATH=$PATH:$HOME/vendor/bin
-EOF
-
-
+mkdir -p "$BUILD_DIR/.profile.d"
+cp "$BP_DIR"/profile/* "$BUILD_DIR/.profile.d/"
 echo "-----> Done"
 exit 0
-
-echo "-----> Buildpack installed"

--- a/profile/sentry-cli.sh
+++ b/profile/sentry-cli.sh
@@ -1,0 +1,1 @@
+export PATH="$PATH:$HOME/vendor/bin"


### PR DESCRIPTION
Before this fix, your buildpack was overwriting PATH (because PATH was being expanding at buildtime, instead of runtime) which meant it wasn't playing nice with none python buildpacks...

